### PR TITLE
Remove potion effects from events when players are sent home

### DIFF
--- a/src/main/java/net/simpvp/Events/EventPlayer.java
+++ b/src/main/java/net/simpvp/Events/EventPlayer.java
@@ -179,6 +179,9 @@ public class EventPlayer {
 	 *  @param player Bukkit.entity.Player object for the player 
 	 */
 	public void sendHome(final Player player) {
+		for (PotionEffect effect: player.getActivePotionEffects()) {
+			player.removePotionEffect(effect.getType());
+		}
 		playerLastJoinTime.put(uuid, System.currentTimeMillis());
 		player.getInventory().setArmorContents(armorContents);
 		player.getInventory().setContents(inventoryContents);

--- a/src/main/java/net/simpvp/Events/EventPlayer.java
+++ b/src/main/java/net/simpvp/Events/EventPlayer.java
@@ -179,15 +179,15 @@ public class EventPlayer {
 	 *  @param player Bukkit.entity.Player object for the player 
 	 */
 	public void sendHome(final Player player) {
-		for (PotionEffect effect: player.getActivePotionEffects()) {
-			player.removePotionEffect(effect.getType());
-		}
 		playerLastJoinTime.put(uuid, System.currentTimeMillis());
 		player.getInventory().setArmorContents(armorContents);
 		player.getInventory().setContents(inventoryContents);
 		player.setGameMode(playerGameMode);
 		player.setFoodLevel(foodLevel);
 		player.setHealth(playerHealth);
+		for (PotionEffect effect: player.getActivePotionEffects()) {
+			player.removePotionEffect(effect.getType());
+		}
 		player.addPotionEffects(potionEffects);
 		player.setLevel(playerLevel);
 		player.setExp(playerXP);

--- a/src/main/java/net/simpvp/Events/PlayerDeath.java
+++ b/src/main/java/net/simpvp/Events/PlayerDeath.java
@@ -29,7 +29,7 @@ public class PlayerDeath implements Listener {
 
 		event.setDroppedExp(0);
 
-		if (Event.getKeepMyInventory() == true) {
+		if (Event.getKeepMyInventory()) {
 			if (!eplayer.getIsQuitting()) {
 				event.setKeepInventory(true);
 			}


### PR DESCRIPTION
When players quit Minecraft during an event, they currently retain any effects from the event. This should fix that.