### PR TITLE
Change player quit event priority to low

### DIFF
--- a/src/main/java/net/simpvp/Events/PlayerQuit.java
+++ b/src/main/java/net/simpvp/Events/PlayerQuit.java
@@ -13,7 +13,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
  */
 public class PlayerQuit implements Listener {
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled=true)
 	public void onPlayerQuit(PlayerQuitEvent event) {
 
 		UUID uuid = event.getPlayer().getUniqueId();


### PR DESCRIPTION
Players are not being teleported back when they disconnect. This is because of WorldGuard. Changing the priority seems to fix it